### PR TITLE
Bump default rubies to the latest supported versions

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,12 +1,11 @@
 node.default['sprout']['chruby']['auto_change_ruby'] = true
-node.default['sprout']['chruby']['default_ruby'] = 'ruby-2.1.2'
+node.default['sprout']['chruby']['default_ruby'] = 'ruby-2.1.7'
 
 include_attribute 'sprout-base::home'
 node.default['sprout']['chruby']['rubies_dir'] = File.join(node['sprout']['home'], '.rubies')
 node.default['sprout']['chruby']['rubies'] = {
   'ruby' => [
-    '1.9.3-p547',
-    '2.0.0-p451',
-    '2.1.2'
+    '2.0.0-p647',
+    '2.1.7'
   ]
 }

--- a/spec/unit/rubies_spec.rb
+++ b/spec/unit/rubies_spec.rb
@@ -8,9 +8,8 @@ describe 'sprout-chruby::rubies' do
   it 'installs a default list of rubies' do
     runner.converge(described_recipe)
 
-    expect(runner).to run_execute("#{ruby_install_cmd} ruby 1.9.3-p547")
-    expect(runner).to run_execute("#{ruby_install_cmd} ruby 2.0.0-p451")
-    expect(runner).to run_execute("#{ruby_install_cmd} ruby 2.1.2")
+    expect(runner).to run_execute("#{ruby_install_cmd} ruby 2.0.0-p647")
+    expect(runner).to run_execute("#{ruby_install_cmd} ruby 2.1.7")
   end
 
   it 'installs a specified list of rubies' do


### PR DESCRIPTION
- 2.0.0-p647
- 2.1.7

1.9.x was removed because support was dropped on February 23, 2015
2.2.x is not yet added because sprout-chruby cannot yet install it
