### PR TITLE
Support installing Ruby 2.2.x

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,12 +1,11 @@
 node.default['sprout']['chruby']['auto_change_ruby'] = true
-node.default['sprout']['chruby']['default_ruby'] = 'ruby-2.1.2'
+node.default['sprout']['chruby']['default_ruby'] = 'ruby-2.1.7'
 
 include_attribute 'sprout-base::home'
 node.default['sprout']['chruby']['rubies_dir'] = File.join(node['sprout']['home'], '.rubies')
 node.default['sprout']['chruby']['rubies'] = {
   'ruby' => [
-    '1.9.3-p547',
-    '2.0.0-p451',
-    '2.1.2'
+    '2.0.0-p647',
+    '2.1.7'
   ]
 }

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,11 +1,12 @@
 node.default['sprout']['chruby']['auto_change_ruby'] = true
-node.default['sprout']['chruby']['default_ruby'] = 'ruby-2.1.7'
+node.default['sprout']['chruby']['default_ruby'] = 'ruby-2.2.3'
 
 include_attribute 'sprout-base::home'
 node.default['sprout']['chruby']['rubies_dir'] = File.join(node['sprout']['home'], '.rubies')
 node.default['sprout']['chruby']['rubies'] = {
   'ruby' => [
     '2.0.0-p647',
-    '2.1.7'
+    '2.1.7',
+    '2.2.3'
   ]
 }

--- a/recipes/rubies.rb
+++ b/recipes/rubies.rb
@@ -5,6 +5,7 @@ node['sprout']['chruby']['rubies'].each do |ruby_vm, ruby_versions|
   ruby_versions.each do |ruby_version|
     execute "ruby-install --cleanup --rubies-dir #{ruby_install_dir} #{ruby_vm} #{ruby_version}" do
       user node['sprout']['user']
+      environment('GEM_HOME' => nil)
       not_if { Dir.exist?(File.join(ruby_install_dir, [ruby_vm, ruby_version].join('-'))) }
     end
   end

--- a/spec/unit/rubies_spec.rb
+++ b/spec/unit/rubies_spec.rb
@@ -10,6 +10,7 @@ describe 'sprout-chruby::rubies' do
 
     expect(runner).to run_execute("#{ruby_install_cmd} ruby 2.0.0-p647")
     expect(runner).to run_execute("#{ruby_install_cmd} ruby 2.1.7")
+    expect(runner).to run_execute("#{ruby_install_cmd} ruby 2.2.3")
   end
 
   it 'installs a specified list of rubies' do

--- a/spec/unit/rubies_spec.rb
+++ b/spec/unit/rubies_spec.rb
@@ -8,9 +8,8 @@ describe 'sprout-chruby::rubies' do
   it 'installs a default list of rubies' do
     runner.converge(described_recipe)
 
-    expect(runner).to run_execute("#{ruby_install_cmd} ruby 1.9.3-p547")
-    expect(runner).to run_execute("#{ruby_install_cmd} ruby 2.0.0-p451")
-    expect(runner).to run_execute("#{ruby_install_cmd} ruby 2.1.2")
+    expect(runner).to run_execute("#{ruby_install_cmd} ruby 2.0.0-p647")
+    expect(runner).to run_execute("#{ruby_install_cmd} ruby 2.1.7")
   end
 
   it 'installs a specified list of rubies' do


### PR DESCRIPTION
The installer for Rubygems has been changed (see https://github.com/ruby/ruby/commit/a7f03a4659d34a459f915a41f260a1b9299ef219) to use the GEM_HOME variable if present. We need to unset it before we execute ruby-installer.

This also installs the latest Ruby, 2.2.3, and sets it as the default.

See [this build](https://travis-ci.org/wendorf/sprout-chruby/builds/83512298) which shows 2.2.3 failing to install without the fix due to `/Users/travis/src/ruby-2.2.3/lib/rubygems/installer.rb:645:in`verify_gem_home': You don't have write permissions for the /Library/Ruby/Gems/2.0.0 directory. (Gem::FilePermissionError)`

This addresses #2
