### PR TITLE
Update cookbook for macOS High Sierra

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: objective-c
-osx_image: xcode8.2
+os: osx
+osx_image: xcode9.3beta
 rvm: system
 install:
   # we expect sprout to provide homebrew so we should ensure it isn't present

--- a/Gemfile
+++ b/Gemfile
@@ -3,21 +3,8 @@ source 'https://rubygems.org'
 gem 'soloist', require: false
 
 group :development do
-  gem 'chefspec', '< 5.0.0', require: false # >=5.0.0 requires ruby v2.1
-  gem 'cucumber-core', '< 3.1.0', require: false # >=3.1.0 requires ruby v2.1
-  gem 'foodcritic', '< 7.0.0', require: false # >=7.0.0 requires ruby v2.1
-  gem 'rake', require: false
+  gem 'chefspec'
+  gem 'foodcritic'
   gem 'rspec', require: false
-  gem 'rubocop', '< 0.51.0', require: false # >=0.51.0 requires ruby v2.1
+  gem 'rubocop', require: false
 end
-
-# Temporarily lock these gems. Newer versions depend on Ruby >= 2.1.0
-# Remove this once https://github.com/mkocher/soloist/issues/39 is closed
-gem 'chef', '~> 12.8.1', require: false
-gem 'chef-zero', '~> 4.5.0', require: false
-gem 'fauxhai', '< 3.7.0', require: false # >=3.7.0 requires ruby v2.1
-gem 'ffi-yajl', '< 2.3.0', require: false # >=2.3.0 requires ruby v2.1
-gem 'mixlib-shellout', '< 2.3.0', require: false # >=2.3.0 requires ruby v2.2
-gem 'nokogiri', '< 1.7.0', require: false # >=1.7.0 requires ruby v2.1
-gem 'ohai', '< 8.18.0', require: false # >=8.18.0 requires ruby v2.2.2
-gem 'rack', '< 2.0.0', require: false # >=2.0.0 requires ruby v2.2.2

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,3 +1,4 @@
+chef_version     '>= 12.6.0'
 name             'sprout-chruby'
 maintainer       'Pivotal'
 maintainer_email 'sprout-maintainers@googlegroups.com'

--- a/spec/unit/chruby_spec.rb
+++ b/spec/unit/chruby_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'sprout-chruby::chruby' do
   let(:auto_change_ruby) { nil }
 
   before do
-    runner.node.set['sprout']['chruby']['auto_change_ruby'] = auto_change_ruby
+    runner.node.override['sprout']['chruby']['auto_change_ruby'] = auto_change_ruby
 
     runner.converge(described_recipe)
   end

--- a/spec/unit/default_ruby_spec.rb
+++ b/spec/unit/default_ruby_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe 'sprout-chruby::default_ruby' do
     let(:default_ruby) { 'FAKE_RUBY-3.2.1' }
 
     before do
-      runner.node.set['sprout']['chruby']['default_ruby'] = default_ruby
-      runner.node.set['sprout']['chruby']['auto_change_ruby'] = auto_change_ruby
+      runner.node.override['sprout']['chruby']['default_ruby'] = default_ruby
+      runner.node.override['sprout']['chruby']['auto_change_ruby'] = auto_change_ruby
       runner.converge(described_recipe)
     end
 
@@ -43,7 +43,7 @@ RSpec.describe 'sprout-chruby::default_ruby' do
 
   context 'when sprout.chruby.default_ruby is specified' do
     before do
-      runner.node.set['sprout']['chruby']['default_ruby'] = false # nil will not override default attribute
+      runner.node.override['sprout']['chruby']['default_ruby'] = false # nil will not override default attribute
       runner.converge(described_recipe)
     end
 

--- a/spec/unit/rubies_spec.rb
+++ b/spec/unit/rubies_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'sprout-chruby::rubies' do
   end
 
   it 'installs a specified list of rubies' do
-    runner.node.set['sprout']['chruby']['rubies'] = {
+    runner.node.override['sprout']['chruby']['rubies'] = {
       'ruby' => %w[1.9.3],
       'jruby' => %w[1.9.3]
     }
@@ -24,7 +24,7 @@ RSpec.describe 'sprout-chruby::rubies' do
   end
 
   it 'does not install rubies that have already been installed' do
-    runner.node.set['sprout']['chruby']['rubies'] = { 'ruby' => %w[2.1.2] }
+    runner.node.override['sprout']['chruby']['rubies'] = { 'ruby' => %w[2.1.2] }
 
     allow(Dir).to receive(:exist?).and_return(true)
 

--- a/spec/unit/spec_helper.rb
+++ b/spec/unit/spec_helper.rb
@@ -4,7 +4,7 @@ require 'chefspec/librarian'
 
 RSpec.configure do |config|
   config.platform = 'mac_os_x'
-  config.version = '10.12' # via https://github.com/customink/fauxhai/tree/master/lib/fauxhai/platforms/mac_os_x/
+  config.version = '10.13' # via https://github.com/customink/fauxhai/tree/master/lib/fauxhai/platforms/mac_os_x/
   config.before do
     stub_const('ENV', 'SUDO_USER' => 'fauxhai')
     stub_command('which git').and_return(true)


### PR DESCRIPTION
* stop locking gems for compatibility with macOS's EOL'd ruby
* fix rubocop errors
* fix foodcritic errors
* fix chef deprecation warnings